### PR TITLE
Fixed `pic` parameter to accept any content

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ A ``typst`` package for creating **O'RLY?**-style cover pages.
 
 ## Example
 
-```rust
+```typst
+#import "@preview/fauxreilly:0.1.1": orly
+
 #orly(
     color: rgb("#85144b"),
     title: "Learn to Stop Worrying and Love Metathesis",
@@ -23,11 +25,15 @@ A ``typst`` package for creating **O'RLY?**-style cover pages.
 
 ## Usage
 
-First, import the package at the top of your ``typst`` file.  I'm working on getting it submitted to ``typst universe``, but in the meantime, you'll need to do so manually.  See [the documentation](https://typst.app/docs/reference/scripting/#modules) on importing a module for specifics.
+Import the package in your Typst file:
 
-Only one function is exposed, ``#orly()``.  This will create its own page in the document at whatever location you call the function.  In other words, any content in the ``typst`` document that appears before ``#orly()`` is called will be before the O'Rly? page in the PDF that ``typst`` renders.  Anything after the function call will be on subsequent page(s).
+```typst
+#import "@preview/fauxreilly:0.1.1": orly
+```
 
-All content for the title page is passed as options to ``#orly()``.  I included what I figured were the most likely things you'd want to customize without having a million options.  Meanwhile, most of the layout parameters (font sizes, the heights of individual pieces, etc.) are variables within the code, so hopefully aren't too hard to alter if need-be.  None of the options are strictly required, although the text fields are the only ones that can be left empty without potentially breaking the layout.   A few have defaults instead, and those are listed below where applicable.
+Only one function is exposed, ``#orly()``.  This will create its own page in the document at whatever location you call the function.  In other words, any content in the ``typst`` document that appears before ``#orly()`` is called will appear before the O'Rly? page in the PDF that ``typst`` renders.  Anything after the function call will be on subsequent page(s).
+
+All content for the title page is passed as options to ``#orly()``.  I included what I figured were the most likely things you'd want to customize without having a million options.  Meanwhile, most of the layout parameters (font sizes, the heights of individual pieces, etc.) are variables within the code, so hopefully aren't too hard to alter if need-be.  None of the options are strictly required, although the text fields are the only ones that can be left empty without potentially breaking the layout. A few have defaults instead, and those are listed below where applicable.
 
 ### Options
 The order that the options appear in the table is the order they must be sent to the function, unless you specify the option's key along with its value.
@@ -39,7 +45,7 @@ Option | Description | Type | Default |
 | ``font`` | The font for all text except the "publisher" in the bottom-left corner | [``string(s)``](https://typst.app/docs/reference/text/text/#parameters-font) |  Whatever is set in the document context |
 | ``color`` | Accent color.  Used for the background of the title block and of the colored bar at the very top. | [``color``](https://typst.app/docs/reference/visualize/color/) | ``blue`` (typst built-in) |
 | ``top-text`` | The text at the top, just under the color bar | [``string``](https://typst.app/docs/reference/foundations/str/) | Empty |
-| ``pic`` | Image to be used above the title block | [``string``](https://typst.app/docs/reference/visualize/image/#parameters-path) with path to the image | Empty |
+| ``pic`` | Content to be used above the title block. Usually an [``image``](https://typst.app/docs/reference/visualize/image/), but may be any other ``content``, like a CeTZ drawing. | [``string``](https://typst.app/docs/reference/visualize/image/#parameters-path) or ``content`` | Empty |
 | ``title`` | The title of the book | [``string``](https://typst.app/docs/reference/foundations/str/) | Empty |
 | ``title-align`` | How the text is aligned (horizontally) in the title block | [``alignment``](https://typst.app/docs/reference/layout/alignment/) | ``left`` |
 | ``subtitle`` | Text that appears just below the title block | [``string``](https://typst.app/docs/reference/foundations/str/) | Empty |

--- a/lib.typ
+++ b/lib.typ
@@ -1,44 +1,45 @@
+// @typstyle off
 #let orly(
-    font: "",
-    color: blue,
-    top-text: "",
-    pic: "",
-    title: "",
-    title-align: left,
-    subtitle: "",
-    publisher: "",
-    publisher-font: ("Noto Sans", "Arial Rounded MT"),
-    signature: "",
-    margin: (top: 0in)
+  font: "",
+  color: blue,
+  top-text: "",
+  pic: none,
+  title: "",
+  title-align: left,
+  subtitle: "",
+  publisher: "",
+  publisher-font: ("Noto Sans", "Arial Rounded MT"),
+  signature: "",
+  margin: (top: 0in),
 ) = {
-    page(
-        margin: margin,
-        [
-            /**************
-            * VARIABLES
-            ***************/
+  page(
+    margin: margin,
+    [
+      /**************
+       * VARIABLES
+       ***************/
 
-            // Layout
-            #let top-bar-height = 0.33em          // how tall to make the colored bar at the top of the page
+      // Layout
+      #let top-bar-height = 0.33em // how tall to make the colored bar at the top of the page
 
-            // Title block
-            #let title-text-color = white
-            #let title-text-leading = 0.5em
-            #let title-block-height = 12em
+      // Title block
+      #let title-text-color = white
+      #let title-text-leading = 0.5em
+      #let title-block-height = 12em
 
-            // Subtitle
-            #let subtitle-margin = 0.5em         // space between title block and subtitle text
-            #let subtitle-text-size = 1.4em
+      // Subtitle
+      #let subtitle-margin = 0.5em // space between title block and subtitle text
+      #let subtitle-text-size = 1.4em
 
-            // "Publisher" / signature
-            #let publisher-text-size = 2em
-            #let signature-text-size = 0.9em
+      // "Publisher" / signature
+      #let publisher-text-size = 2em
+      #let signature-text-size = 0.9em
 
-            // *********************************************************
+      // *********************************************************
 
-            #set text(font: font) if font != ""
+      #set text(font: font) if font != ""
 
-            #grid(
+      #grid(
                 rows: (
                     top-bar-height,
                     1em,                    // top text
@@ -54,7 +55,7 @@
                 rect(width: 100%, height: 100%, fill: color),                   // color bar at top
                 align(center + bottom)[#emph[#top-text]],                                // top text
                 [],                                                             // pre-image spacing
-                image(pic, width: 100%, fit: "contain"),                        // image
+                pic,                        // image
                 [],                                                             // spacing between image and title block
                 block(width: 100%, height: title-block-height, inset: (x: 2em), fill: color)[    // title block
                     #set text(fill: title-text-color, size: 3em)
@@ -85,8 +86,6 @@
                     }
                 ]
             )
-        ]
-    )
+    ],
+  )
 }
-
-

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
-name = "O'Rly, Typst?"
-version = "0.1.0"
+name = "fauxreilly"
+version = "0.1.1"
 entrypoint = "lib.typ"
 authors = ["Dei Layborer"]
 license = "GPL-3.0"
@@ -8,4 +8,8 @@ compiler = "0.11.1"
 description = "A package for creating O'Rly- / O'Reilly-type cover pages"
 repository = "https://github.com/dei-layborer/o-rly-typst"
 categories = ["components", "layout", "fun"]
-exclude = ["$$$-gimmie.svg", "made-with-(2s)-2,6-diamino-n-[(2s)-1-phenylpropan-2-yl]hexanamide-n-[(2s)-1-phenyl-2-propanyl]-l-lysinamide.svg", "example.png"]
+exclude = [
+	"$$$-gimmie.svg",
+	"made-with-(2s)-2,6-diamino-n-[(2s)-1-phenylpropan-2-yl]hexanamide-n-[(2s)-1-phenyl-2-propanyl]-l-lysinamide.svg",
+	"example.png",
+]


### PR DESCRIPTION
This pull request fixes the use of `image` in the main `orly` function. Since packages may not load resources from outside their package folder, images passed into the function will cause an error. This fixes that and allows `pic`  to be any content.

A user now needs to pass in the `image` themselves:

```typst
#orly(
    // ...
   pic: image("assets/logo.png", width:100%)
)
```